### PR TITLE
fix running multiple signed kernels

### DIFF
--- a/scripts/abk
+++ b/scripts/abk
@@ -75,7 +75,8 @@ install_kernel() {
 
 	pkglist=$(ls $pkgdir/*$pkgver* | grep -v doc)
 
-	sudo pacman -U $pkglist
+	# overwrite required for multiple signed kernels
+	sudo pacman -U $pkglist --overwrite /etc/dkms/kernel-sign.conf --overwrite /etc/dkms/kernel-sign.sh
 }
 
 


### PR DESCRIPTION
 * `/etc/dkms/kernel-sign.(conf|sh)` are included with the built
   kernel headers. Force overwrite them so multiple signed kernels
   can be run side by side.