### PR TITLE
additional asp fix / add 'Avoid creating the doc' example

### DIFF
--- a/Arch-Linux-PKGBUILD-example
+++ b/Arch-Linux-PKGBUILD-example
@@ -52,6 +52,9 @@ prepare() {
 
 build() {
   ....
+  # see https://wiki.archlinux.org/index.php/Kernel/Arch_Build_System
+  # 'Avoid creating the doc'
+  #make htmldocs
 }
 
 _package() {
@@ -88,3 +91,8 @@ _package-headers() {
 _package-docs() {
   ....
 }
+
+# see https://wiki.archlinux.org/index.php/Kernel/Arch_Build_System
+# 'Avoid creating the doc'
+#pkgname=("$pkgbase" "$pkgbase-headers" "$pkgbase-docs")
+pkgname=("$pkgbase" "$pkgbase-headers")

--- a/scripts/abk
+++ b/scripts/abk
@@ -93,6 +93,12 @@ update_kernel(){
 	local status=
 
 	cd $BUILD_DIR
+
+	# asp no longer has a force option
+	if [ -d $KERNEL ]; then
+		rm -rf $KERNEL
+	fi
+
 	asp update $KERNEL
 	status=$?
 


### PR DESCRIPTION
* remove previous build directory now `asp` no longer has `-f` switch
* adds 'Avoid creating the doc' example to `/usr/share/arch-sign-modules/PKGBUILD.example`