### PR TITLE
Add support for ZSTD module compression

### DIFF
--- a/certs-local/dkms/kernel-sign.sh
+++ b/certs-local/dkms/kernel-sign.sh
@@ -15,7 +15,7 @@ SIGN=/usr/lib/modules/$kernelver/build/certs-local/sign_manual.sh
 
 if [ -f $SIGN ] ;then
 
-   list=$(/bin/ls -1 *.ko *.ko.xz 2>/dev/null)
+   list=$(/bin/ls -1 *.ko *.ko.xz *.ko.zst 2>/dev/null)
 
    if [ "$list" != "" ]  ; then
        for mod in $list

--- a/certs-local/sign_manual.sh
+++ b/certs-local/sign_manual.sh
@@ -88,6 +88,13 @@ do
         xz -f --decompress $mod_tmp
         mod_tmp=${mod_tmp%*.xz}
     fi
+    iszst='n'
+    if [ "$ext" = "zst" ] ; then
+        echo "Decompressing :"
+        iszst='y'
+        zstd -dfq $mod_tmp
+        mod_tmp=${mod_tmp%*.zst}
+    fi
 
     #
     # remove any existing signature before signing
@@ -105,6 +112,11 @@ do
         echo "Compressing:"
         xz -f $mod_tmp
         mod_tmp=${mod_tmp}.xz
+    fi
+    if [ "$iszst" = "y" ] ; then
+        echo "Compressing:"
+        zstd -fq $mod_tmp
+        mod_tmp=${mod_tmp}.zst
     fi
 
     #


### PR DESCRIPTION
Enabled by default in 5.13+ Arch Linux kernels: [linux](https://github.com/archlinux/svntogit-packages/commit/89c24952adbfa645d9e1a6f12c572929f7e4e3c7#diff-6503b30d816e211d1909eed3e1eff5f9105fdc48f5735921a59f4906f99415beR920-R921), [linux-zen](https://github.com/archlinux/svntogit-packages/commit/dc03dd77c8d33f5a42e39fb893bb0cd26b924d4a#diff-6503b30d816e211d1909eed3e1eff5f9105fdc48f5735921a59f4906f99415beR964-R965).
