### PR TITLE
Changes for 0.2.61

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
-Version [0.2.6]                                                    - 20210830
+Version [0.2.61]                                                    - 20210906
+ - Add archive_config() to create tar.xz archive of existing kernel configuration
+   during update_kernel()
+
+Version [0.2.60]                                                    - 20210830
  - Command line switches & help menu implemented with getops
  - Add functionality to build AUR kernels
  - Add functionality to change module compression algorithm

--- a/arch-sign-modules/PKGBUILD
+++ b/arch-sign-modules/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Stuart Cardall <developer__at__it-offshore.co.uk>
 pkgname=arch-sign-modules
 _pkgname=Arch-SKM
-pkgver=0.2.60
+pkgver=0.2.61
 pkgrel=0
 pkgdesc="Signed (In Tree & Out of Tree) Kernel Modules for linux linux-lts linux-hardened linux-zen + AUR kernels"
 arch=(x86_64)

--- a/scripts/abk
+++ b/scripts/abk
@@ -195,6 +195,23 @@ check_compress() {
 	fi
 }
 
+archive_config() {
+	# Archive kernel configs
+	local archive=
+
+	# source PKGBUILD vars
+	check_pkgver
+	archive=$KERNEL-$pkgver.tar.xz
+
+	cd $BUILD_DIR
+
+	# create archive
+	if [ -d $KERNEL ]; then
+		printf "Backing up: $KBUILD_DIR => $BUILD_DIR/$archive\n"
+		tar -cJf $archive -C $BUILD_DIR $KERNEL
+	fi
+}
+
 install_kernel() {
 	# display list of built kernel + header versions
 	local pkglist= ksign='/etc/dkms/kernel-sign' tmp=$(mktemp)
@@ -245,8 +262,9 @@ update_kernel() {
 
 	cd $BUILD_DIR
 
-	# clean old config
+	# backup & clean old config
 	if [ -d $KERNEL ]; then
+		archive_config $KERNEL
 		clean_dir $KBUILD_DIR build
 	fi
 


### PR DESCRIPTION
Adds `archive_config()` to backup existing kernel configuration during `update_kernel()`