### PR TITLE
add PKGBUILD patch support

### DIFF
--- a/patches/linux-amd.patch
+++ b/patches/linux-amd.patch
@@ -1,0 +1,72 @@
+--- PKGBUILD.orig	2022-05-04 13:49:26.745366029 +0100
++++ PKGBUILD	2022-05-04 13:52:24.646487838 +0100
+@@ -41,7 +41,35 @@ pkgver() {
+ }
+ 
+ prepare() {
+-  cd "${_srcname}"
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../config*'
++
++  cd ../$_srcname
++
++# cd $_srcname
++
+   if [ "${CARCH}" = "x86_64" ]; then
+     cat "${srcdir}/config.x86_64" > ./.config
+   else
+@@ -229,6 +257,32 @@ _package-headers() {
+    rm -rf $modarch
+   done <<< $(find "${pkgdir}"/usr/lib/modules/${_kernver}/build/arch/ -maxdepth 1 -mindepth 1 -type d | grep -v /x86$)
+ 
++  # Out-of-tree module signing
++  ##################################################
++  # this is added at the end of _package-headers() #
++  ##################################################
++  # This is run in the kernel source / build directory
++  #
++  # some AUR kernels may also need to set $builddir to match
++  # the Package Maintainer's variable for the build dir
++  # inside the package:
++  #
++  # local builddir="$pkgdir/usr/lib/modules/${_kernver}/build"
++
++  msg2 "Local Signing certs for out-of-tree modules..."
++
++  certs_local_src="../certs-local"
++  certs_local_dst="${builddir}/certs-local"
++
++  # install certificates
++  ${certs_local_src}/install-certs.py $certs_local_dst
++
++  # install dkms tools
++  dkms_src="$certs_local_src/dkms"
++  dkms_dst="${pkgdir}/etc/dkms"
++  mkdir -p $dkms_dst
++
++  rsync -a $dkms_src/{kernel-sign.conf,kernel-sign.sh} $dkms_dst/
+ }
+ 
+ _package-docs() {

--- a/patches/linux-ck.patch
+++ b/patches/linux-ck.patch
@@ -1,0 +1,72 @@
+--- PKGBUILD.orig	2022-05-04 14:16:36.336143903 +0100
++++ PKGBUILD	2022-05-04 14:23:20.101037539 +0100
+@@ -116,7 +116,34 @@ sha256sums=('9bbcd185b94436f9c8fe977fa0e
+             'a0c3ecc39c58349e6bd1444d42f598ec189f53c267e80d48c66e945c91a7b831')
+ 
+ prepare() {
+-  cd linux-${pkgver}
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../config*'
++
++  cd ../linux-${pkgver}
++
++#  cd linux-${pkgver}
+ 
+   msg2 "Setting version..."
+   scripts/setlocalversion --save-scmversion
+@@ -336,6 +363,33 @@ _package-headers() {
+   echo "Adding symlink..."
+   mkdir -p "$pkgdir/usr/src"
+   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
++
++  # Out-of-tree module signing
++  ##################################################
++  # this is added at the end of _package-headers() #
++  ##################################################
++  # This is run in the kernel source / build directory
++  #
++  # some AUR kernels may also need to set $builddir to match
++  # the Package Maintainer's variable for the build dir
++  # inside the package:
++  #
++  # local builddir="$pkgdir/usr/lib/modules/${_kernver}/build"
++
++  msg2 "Local Signing certs for out-of-tree modules..."
++
++  certs_local_src="../certs-local"
++  certs_local_dst="${builddir}/certs-local"
++
++  # install certificates
++  ${certs_local_src}/install-certs.py $certs_local_dst
++
++  # install dkms tools
++  dkms_src="$certs_local_src/dkms"
++  dkms_dst="${pkgdir}/etc/dkms"
++  mkdir -p $dkms_dst
++
++  rsync -a $dkms_src/{kernel-sign.conf,kernel-sign.sh} $dkms_dst/
+ }
+ 
+ pkgname=("$pkgbase" "$pkgbase-headers")

--- a/patches/linux-hardened.patch
+++ b/patches/linux-hardened.patch
@@ -1,0 +1,99 @@
+--- PKGBUILD.txt	2022-05-04 02:50:43.939160024 +0100
++++ PKGBUILD	2022-05-04 02:52:51.408482369 +0100
+@@ -12,7 +12,7 @@ arch=(x86_64)
+ license=(GPL2)
+ makedepends=(
+   bc libelf pahole cpio perl tar xz
+-  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick texlive-latexextra
++  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick
+   git
+ )
+ options=('!strip')
+@@ -39,7 +39,34 @@ export KBUILD_BUILD_USER=$pkgbase
+ export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EPOCH})"
+ 
+ prepare() {
+-  cd $_srcname
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../config*'
++
++  cd ../$_srcname
++
++# cd $_srcname
+ 
+   echo "Setting version..."
+   scripts/setlocalversion --save-scmversion
+@@ -67,7 +94,7 @@ prepare() {
+ build() {
+   cd $_srcname
+   make all
+-  make htmldocs
++# make htmldocs
+ }
+ 
+ _package() {
+@@ -178,6 +205,33 @@ _package-headers() {
+   echo "Adding symlink..."
+   mkdir -p "$pkgdir/usr/src"
+   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
++
++  # Out-of-tree module signing
++  ##################################################
++  # this is added at the end of _package-headers() #
++  ##################################################
++  # This is run in the kernel source / build directory
++  #
++  # some AUR kernels may also need to set $builddir to match
++  # the Package Maintainer's variable for the build dir
++  # inside the package:
++  #
++  # local builddir="$pkgdir/usr/lib/modules/${_kernver}/build"
++
++  msg2 "Local Signing certs for out-of-tree modules..."
++
++  certs_local_src="../certs-local"
++  certs_local_dst="${builddir}/certs-local"
++
++  # install certificates
++  ${certs_local_src}/install-certs.py $certs_local_dst
++
++  # install dkms tools
++  dkms_src="$certs_local_src/dkms"
++  dkms_dst="${pkgdir}/etc/dkms"
++  mkdir -p $dkms_dst
++
++  rsync -a $dkms_src/{kernel-sign.conf,kernel-sign.sh} $dkms_dst/
+ }
+ 
+ _package-docs() {
+@@ -199,7 +253,7 @@ _package-docs() {
+   ln -sr "$builddir/Documentation" "$pkgdir/usr/share/doc/$pkgbase"
+ }
+ 
+-pkgname=("$pkgbase" "$pkgbase-headers" "$pkgbase-docs")
++pkgname=("$pkgbase" "$pkgbase-headers")
+ for _p in "${pkgname[@]}"; do
+   eval "package_$_p() {
+     $(declare -f "_package${_p#$pkgbase}")

--- a/patches/linux-libre.patch
+++ b/patches/linux-libre.patch
@@ -1,0 +1,90 @@
+--- PKGBUILD.orig	2022-05-04 05:33:52.227378497 +0100
++++ PKGBUILD	2022-05-04 05:35:20.872739319 +0100
+@@ -25,7 +25,7 @@ arch=(i686 x86_64 armv7h)
+ license=(GPL2)
+ makedepends=(
+   bc libelf pahole cpio perl tar xz
+-  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick texlive-latexextra
++  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick
+   git
+ )
+ makedepends=( ${makedepends[*]/git/} )
+@@ -146,7 +146,34 @@ export KBUILD_BUILD_USER=$pkgbase
+ export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EPOCH})"
+ 
+ prepare() {
+-  cd $_srcname
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../config*'
++
++  cd ../$_srcname
++
++# cd $_srcname
+ 
+   if [ "${_srcname##*-}" != "$pkgver" ]; then
+     echo "Applying upstream patch..."
+@@ -341,6 +368,33 @@ _package-headers() {
+   echo "Adding symlink..."
+   mkdir -p "$pkgdir/usr/src"
+   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
++
++  # Out-of-tree module signing
++  ##################################################
++  # this is added at the end of _package-headers() #
++  ##################################################
++  # This is run in the kernel source / build directory
++  #
++  # some AUR kernels may also need to set $builddir to match
++  # the Package Maintainer's variable for the build dir
++  # inside the package:
++  #
++  # local builddir="$pkgdir/usr/lib/modules/${_kernver}/build"
++
++  msg2 "Local Signing certs for out-of-tree modules..."
++
++  certs_local_src="../certs-local"
++  certs_local_dst="${builddir}/certs-local"
++
++  # install certificates
++  ${certs_local_src}/install-certs.py $certs_local_dst
++
++  # install dkms tools
++  dkms_src="$certs_local_src/dkms"
++  dkms_dst="${pkgdir}/etc/dkms"
++  mkdir -p $dkms_dst
++
++  rsync -a $dkms_src/{kernel-sign.conf,kernel-sign.sh} $dkms_dst/
+ }
+ 
+ _package-docs() {
+@@ -393,7 +447,7 @@ _package-chromebook() {
+   cp vmlinux.kpart "$pkgdir/boot"
+ }
+ 
+-pkgname=("$pkgbase" "$pkgbase-headers" "$pkgbase-docs")
++pkgname=("$pkgbase" "$pkgbase-headers")
+ [[ $CARCH = armv7h ]] && pkgname+=("$pkgbase-chromebook")
+ for _p in "${pkgname[@]}"; do
+   eval "package_$_p() {

--- a/patches/linux-lts.patch
+++ b/patches/linux-lts.patch
@@ -1,0 +1,99 @@
+--- PKGBUILD.txt	2022-05-04 02:34:22.925648854 +0100
++++ PKGBUILD	2022-05-04 02:43:11.856448499 +0100
+@@ -9,7 +9,7 @@ arch=(x86_64)
+ license=(GPL2)
+ makedepends=(
+   bc libelf pahole cpio perl tar xz
+-  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick texlive-latexextra
++  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick
+ )
+ options=('!strip')
+ _srcname=linux-$pkgver
+@@ -43,7 +43,34 @@ export KBUILD_BUILD_USER=$pkgbase
+ export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EPOCH})"
+ 
+ prepare() {
+-  cd $_srcname
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../config*'
++
++  cd ../$_srcname
++
++# cd $_srcname
+ 
+   # fix NFSv4 mounting issue regression - FS#73838 / FS#73860
+   # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/patch/?id=6f2836341d8a39e1e000572b10959347d7e61fd9
+@@ -75,7 +102,7 @@ prepare() {
+ build() {
+   cd $_srcname
+   make all
+-  make htmldocs
++# make htmldocs
+ }
+ 
+ _package() {
+@@ -186,6 +213,33 @@ _package-headers() {
+   echo "Adding symlink..."
+   mkdir -p "$pkgdir/usr/src"
+   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
++
++  # Out-of-tree module signing
++  ##################################################
++  # this is added at the end of _package-headers() #
++  ##################################################
++  # This is run in the kernel source / build directory
++  #
++  # some AUR kernels may also need to set $builddir to match
++  # the Package Maintainer's variable for the build dir
++  # inside the package:
++  #
++  # local builddir="$pkgdir/usr/lib/modules/${_kernver}/build"
++
++  msg2 "Local Signing certs for out-of-tree modules..."
++
++  certs_local_src="../certs-local"
++  certs_local_dst="${builddir}/certs-local"
++
++  # install certificates
++  ${certs_local_src}/install-certs.py $certs_local_dst
++
++  # install dkms tools
++  dkms_src="$certs_local_src/dkms"
++  dkms_dst="${pkgdir}/etc/dkms"
++  mkdir -p $dkms_dst
++
++  rsync -a $dkms_src/{kernel-sign.conf,kernel-sign.sh} $dkms_dst/
+ }
+ 
+ _package-docs() {
+@@ -207,7 +261,7 @@ _package-docs() {
+   ln -sr "$builddir/Documentation" "$pkgdir/usr/share/doc/$pkgbase"
+ }
+ 
+-pkgname=("$pkgbase" "$pkgbase-headers" "$pkgbase-docs")
++pkgname=("$pkgbase" "$pkgbase-headers")
+ for _p in "${pkgname[@]}"; do
+   eval "package_$_p() {
+     $(declare -f "_package${_p#$pkgbase}")

--- a/patches/linux-zen.patch
+++ b/patches/linux-zen.patch
@@ -1,0 +1,99 @@
+--- PKGBUILD.orig	2022-05-04 05:40:59.439873028 +0100
++++ PKGBUILD	2022-05-04 05:42:18.287720507 +0100
+@@ -10,7 +10,7 @@ arch=(x86_64)
+ license=(GPL2)
+ makedepends=(
+   bc libelf pahole cpio perl tar xz
+-  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick texlive-latexextra
++  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick
+   git
+ )
+ options=('!strip')
+@@ -33,7 +33,34 @@ export KBUILD_BUILD_USER=$pkgbase
+ export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EPOCH})"
+ 
+ prepare() {
+-  cd $_srcname
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../config*'
++
++  cd ../$_srcname
++
++# cd $_srcname
+ 
+   echo "Setting version..."
+   scripts/setlocalversion --save-scmversion
+@@ -61,7 +88,7 @@ prepare() {
+ build() {
+   cd $_srcname
+   make all
+-  make htmldocs
++# make htmldocs
+ }
+ 
+ _package() {
+@@ -172,6 +199,33 @@ _package-headers() {
+   echo "Adding symlink..."
+   mkdir -p "$pkgdir/usr/src"
+   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
++
++  # Out-of-tree module signing
++  ##################################################
++  # this is added at the end of _package-headers() #
++  ##################################################
++  # This is run in the kernel source / build directory
++  #
++  # some AUR kernels may also need to set $builddir to match
++  # the Package Maintainer's variable for the build dir
++  # inside the package:
++  #
++  # local builddir="$pkgdir/usr/lib/modules/${_kernver}/build"
++
++  msg2 "Local Signing certs for out-of-tree modules..."
++
++  certs_local_src="../certs-local"
++  certs_local_dst="${builddir}/certs-local"
++
++  # install certificates
++  ${certs_local_src}/install-certs.py $certs_local_dst
++
++  # install dkms tools
++  dkms_src="$certs_local_src/dkms"
++  dkms_dst="${pkgdir}/etc/dkms"
++  mkdir -p $dkms_dst
++
++  rsync -a $dkms_src/{kernel-sign.conf,kernel-sign.sh} $dkms_dst/
+ }
+ 
+ _package-docs() {
+@@ -193,7 +247,7 @@ _package-docs() {
+   ln -sr "$builddir/Documentation" "$pkgdir/usr/share/doc/$pkgbase"
+ }
+ 
+-pkgname=("$pkgbase" "$pkgbase-headers" "$pkgbase-docs")
++pkgname=("$pkgbase" "$pkgbase-headers")
+ for _p in "${pkgname[@]}"; do
+   eval "package_$_p() {
+     $(declare -f "_package${_p#$pkgbase}")

--- a/patches/linux.patch
+++ b/patches/linux.patch
@@ -1,0 +1,99 @@
+--- PKGBUILD.orig	2022-05-04 05:38:47.040776771 +0100
++++ PKGBUILD	2022-05-04 05:40:14.029231753 +0100
+@@ -10,7 +10,7 @@ arch=(x86_64)
+ license=(GPL2)
+ makedepends=(
+   bc libelf pahole cpio perl tar xz
+-  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick texlive-latexextra
++  xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick
+   git
+ )
+ options=('!strip')
+@@ -33,7 +33,34 @@ export KBUILD_BUILD_USER=$pkgbase
+ export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EPOCH})"
+ 
+ prepare() {
+-  cd $_srcname
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../config*'
++
++  cd ../$_srcname
++
++# cd $_srcname
+ 
+   echo "Setting version..."
+   scripts/setlocalversion --save-scmversion
+@@ -61,7 +88,7 @@ prepare() {
+ build() {
+   cd $_srcname
+   make all
+-  make htmldocs
++# make htmldocs
+ }
+ 
+ _package() {
+@@ -172,6 +199,33 @@ _package-headers() {
+   echo "Adding symlink..."
+   mkdir -p "$pkgdir/usr/src"
+   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
++
++  # Out-of-tree module signing
++  ##################################################
++  # this is added at the end of _package-headers() #
++  ##################################################
++  # This is run in the kernel source / build directory
++  #
++  # some AUR kernels may also need to set $builddir to match
++  # the Package Maintainer's variable for the build dir
++  # inside the package:
++  #
++  # local builddir="$pkgdir/usr/lib/modules/${_kernver}/build"
++
++  msg2 "Local Signing certs for out-of-tree modules..."
++
++  certs_local_src="../certs-local"
++  certs_local_dst="${builddir}/certs-local"
++
++  # install certificates
++  ${certs_local_src}/install-certs.py $certs_local_dst
++
++  # install dkms tools
++  dkms_src="$certs_local_src/dkms"
++  dkms_dst="${pkgdir}/etc/dkms"
++  mkdir -p $dkms_dst
++
++  rsync -a $dkms_src/{kernel-sign.conf,kernel-sign.sh} $dkms_dst/
+ }
+ 
+ _package-docs() {
+@@ -193,7 +247,7 @@ _package-docs() {
+   ln -sr "$builddir/Documentation" "$pkgdir/usr/share/doc/$pkgbase"
+ }
+ 
+-pkgname=("$pkgbase" "$pkgbase-headers" "$pkgbase-docs")
++pkgname=("$pkgbase" "$pkgbase-headers")
+ for _p in "${pkgname[@]}"; do
+   eval "package_$_p() {
+     $(declare -f "_package${_p#$pkgbase}")

--- a/scripts/abk
+++ b/scripts/abk
@@ -106,7 +106,7 @@ check_kernel() {
 		else
 
 			warning "Add '$KERNEL' to AUR_KERNELS in: $USER_CONFIG"
-			msg2 "Assuming '$KERNEL' is from AUR\n"
+			msg2 "Assuming '$KERNEL' is from AUR"
 			REPO='aur'
 		fi
 	fi
@@ -380,7 +380,7 @@ update_kernel() {
 			error "$err_msg"
 			die $KBUILD_DIR
 		else
-			asp export $KERNEL
+			msg "$(asp export $KERNEL)"
 		fi
 
 	elif [ "$kernel_repo" = "aur" ]; then
@@ -397,8 +397,11 @@ update_kernel() {
 	fi
 
 	# edit files
-	$GUI_EDITOR $EXAMPLES &
-	$CONSOLE_EDITOR $KBUILD_DIR/PKGBUILD
+#	$GUI_EDITOR $EXAMPLES &
+#	$CONSOLE_EDITOR $KBUILD_DIR/PKGBUILD
+
+	# experimental automated update
+	patch_pkgbuild
 }
 
 build_kernel() {
@@ -553,6 +556,75 @@ die() {
 	fi
 
 	exit 1
+}
+
+edit_pkgbuild() {
+        # edit files
+        $GUI_EDITOR $EXAMPLES &
+        $CONSOLE_EDITOR $KBUILD_DIR/PKGBUILD
+}
+
+patch_pkgbuild() {
+	# initial support for running update step automated
+	local patch_dir=/usr/share/arch-sign-modules/patches
+	local patch_file=$patch_dir/$KERNEL.patch ans=
+	local pkgbuild=$KBUILD_DIR/PKGBUILD
+
+	cd $KBUILD_DIR
+
+	if [ -f $patch_file ]; then
+		msg "Testing $patch_file on $pkgbuild"
+		patch -s -p0 --dry-run < $patch_file
+
+		if [ $? = 0 ]; then
+			msg "$(patch -p0 < $patch_file)"
+			msg2 "Ready to run: $0 -b $KERNEL"
+		else
+			error "Cannot cleanly patch $pkgbuild"
+			ask "Remove $patch_file ? [Y/n] : "
+
+			case "$ans" in
+			    "") sudo rm -f $patch_file
+				msg "Removed $patch_file & restarting update_kernel()"
+
+				# next time branches to 'else'
+				update_kernel $REPO
+				;;
+			     *) error "Exiting with patch errors on $pkgbuild"; die ;;
+			esac
+		fi
+	else
+		error "No patch exists for kernel: $KERNEL"
+		ask "Start $GUI_EDITOR / $CONSOLE_EDITOR & generate a new patchset ? [Y/n] : "; read ans
+
+		case "$ans" in
+			"") patch_generator ;;
+			 *) error "Exiting with unpatched $pkgbuild" ; die ;;
+		esac
+	fi
+}
+
+patch_generator() {
+	local patch_dir=/usr/share/arch-sign-modules/patches
+	local ans= pkgbuild=$KBUILD_DIR/PKGBUILD
+
+	msg "Backing up $pkgbuild => $pkgbuild.orig"
+	cp PKGBUILD PKGBUILD.orig
+
+	# re-run manual step
+	edit_pkgbuild
+
+	diff -up PKGBUILD.orig PKGBUILD > $KERNEL.patch
+	ask "Copy $KERNEL.patch to $patch_dir ? [Y/n] : "; read ans
+
+	case "$ans" in
+		"") sudo cp $KERNEL.patch $patch_dir
+		    sudo chmod 644 $patch_dir/$KERNEL.patch
+		    msg "To test the patch just re-run: $0 -u $KERNEL"
+		    msg "If the new patch works please consider making a Pull Request ;o)"
+		    msg "(or just open a Github issue & paste in your patch so I can test)"
+		    ;;
+	esac
 }
 
 parse_makepkg() {


### PR DESCRIPTION
experimental functionality to automate the update step

* adds `patch_pkgbuild()` & `patch_generator()`
* with patches for officially supported kernels + some others:
```
* linux-amd.patch
* linux-ck.patch
* linux-hardened.patch
* linux-libre.patch
* linux-lts.patch
* linux.patch
* linux-zen.patch
```
`linux-hardened` & `linux-lts` will always be regularly tested.

If a patch cannot be cleanly applied an option is given to generate a new patchset.