### PR TITLE
update PKGBUILD for 0.3.2 release

### DIFF
--- a/arch-sign-modules/.SRCINFO
+++ b/arch-sign-modules/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = arch-sign-modules
 	pkgdesc = Signed (In Tree & Out of Tree) Kernel Modules for linux linux-lts linux-hardened linux-zen + AUR kernels
-	pkgver = 0.3.1
+	pkgver = 0.3.2
 	pkgrel = 0
 	url = https://github.com/itoffshore/Arch-SKM
 	install = arch-sign-modules.install
@@ -8,8 +8,9 @@ pkgbase = arch-sign-modules
 	license = GPL
 	depends = asp
 	depends = rsync
+	depends = python-zstandard
 	optdepends = pacman-contrib
-	source = arch-sign-modules-0.3.1.tar.gz::https://github.com/itoffshore/Arch-SKM/archive/0.3.1.tar.gz
-	md5sums = bc75aa16c6e0c305db4093e46dc61555
+	source = arch-sign-modules-0.3.2.tar.gz::https://github.com/itoffshore/Arch-SKM/archive/0.3.2.tar.gz
+	md5sums = b324f0b2414c3db3696a3bf763f6cb80
 
 pkgname = arch-sign-modules

--- a/arch-sign-modules/PKGBUILD
+++ b/arch-sign-modules/PKGBUILD
@@ -1,18 +1,18 @@
 # Maintainer: Stuart Cardall <developer__at__it-offshore.co.uk>
 pkgname=arch-sign-modules
 _pkgname=Arch-SKM
-pkgver=0.3.1
+pkgver=0.3.2
 pkgrel=0
 pkgdesc="Signed (In Tree & Out of Tree) Kernel Modules for linux linux-lts linux-hardened linux-zen + AUR kernels"
 arch=(x86_64)
 url="https://github.com/itoffshore/Arch-SKM"
 license=(GPL)
-depends=('asp' 'rsync')
+depends=('asp' 'rsync' 'python-zstandard')
 optdepends=('pacman-contrib')
 makedepends=()
 install="$pkgname.install"
 source=($pkgname-$pkgver.tar.gz::https://github.com/itoffshore/$_pkgname/archive/$pkgver.tar.gz)
-md5sums=('bc75aa16c6e0c305db4093e46dc61555')
+md5sums=('b324f0b2414c3db3696a3bf763f6cb80')
 
 build() {
   return 0
@@ -25,5 +25,6 @@ package() {
   cp -rf certs-local $pkgdir/usr/src/
   cp scripts/* $pkgdir/usr/bin/
   cp Arch-Linux-PKGBUILD-example $pkgdir/usr/share/$pkgname/PKGBUILD.example
+  cp -rf patches $pkgdir/usr/share/$pkgname/patches
   cp README.scripts.md $pkgdir/usr/share/$pkgname/README.scripts.md
 }


### PR DESCRIPTION
* update `PKGBUILD` for `0.3.2` release
* adds `python-zstandard` as a depends now that the `2.2.0` release of [Arch-SKM is pure python](https://github.com/gene-git/Arch-SKM/releases/tag/2.2.0)
* kernel modules now have `ECDSA` signatures which you may notice are shorter in `modinfo`   