### PR TITLE
ignore 'local' error in shellcheck

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,9 +5,12 @@ on:
     types:
       - opened
       - reopened
+
 jobs:
   shell_linter:
     runs-on: ubuntu-latest
+    env:
+      SHELLCHECK_OPTS: "-e SC2039"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
* most shells support `local` except possibly Solaris