### PR TITLE
Add acpi_call

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ With **DKMS** support for the following _Out of Tree_ Kernel Modules:
 * [ZFS](https://aur.archlinux.org/packages/zfs-dkms/)
 * [Nvidia](https://archlinux.org/packages/extra/x86_64/nvidia-dkms/)
 * [Linux Kernel Runtime Guard](https://aur.archlinux.org/packages/lkrg-dkms/)
+* [acpi_call](https://archlinux.org/packages/community/any/acpi_call-dkms/)
 
 ---
 

--- a/arch-sign-modules/arch-sign-modules.install
+++ b/arch-sign-modules/arch-sign-modules.install
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 post_install() {
-	local x= module_list="zfs nvidia"
+	local x= module_list="zfs nvidia acpi_call"
 	local dkms_dir=/etc/dkms dkms_link=
 	local kernel_sign=${dkms_dir}/kernel-sign.conf
 
@@ -30,7 +30,7 @@ post_upgrade() {
 }
 
 post_remove() {
-	local x= module_list="zfs nvidia lkrg"
+	local x= module_list="zfs nvidia lkrg acpi_call"
 	local dkms_dir=/etc/dkms dkms_link=
 
 	for x in $module_list; do


### PR DESCRIPTION
Having this added to the AUR package would allow signing the [acpi_call](https://archlinux.org/packages/community/any/acpi_call-dkms/) module aswell!
I'm publishing this as a draft since I didn't test this yet.