### PR TITLE
Fix new kernel cloning / add linux-xanmod support

### DIFF
--- a/patches/linux-xanmod.patch
+++ b/patches/linux-xanmod.patch
@@ -1,0 +1,36 @@
+--- PKGBUILD.orig	2022-10-19 00:36:07.119531703 +0100
++++ PKGBUILD	2022-10-19 00:38:16.515737400 +0100
+@@ -220,6 +220,33 @@ prepare() {
+ 
+   # save configuration for later reuse
+   cat .config > "${SRCDEST}/config.last"
++
++  # Out-of-tree module signing
++  #
++  ######################################################
++  # this is added at the start of prepare() & replaces #
++  # 'cd $_srcname'                                     #
++  ######################################################
++  # uncomment for linux-xanmod-cacule & some other AUR kernels
++  # to match the Package Maintainer's variable for the kernel
++  # sources directory.
++  #
++  # local _srcname=linux-${_major}
++
++  msg2 "Rebuilding local signing key..."
++
++  cp -rf /usr/src/certs-local ./
++  cd certs-local
++
++  msg2 "Updating kernel config with new key..."
++
++  # NB: config path must be quoted for file globbing to work
++  # some kernels have multiple config files (e.g linux-libre)
++  # to see configurable options run:
++  # /usr/src/certs-local/genkeys.py -h
++  ./genkeys.py -v --config '../.config*'
++
++  #cd ../$_srcname
+ }
+ 
+ build() {

--- a/scripts/abk
+++ b/scripts/abk
@@ -6,7 +6,7 @@
 # --------------------------------------
 # https://github.com/itoffshore/Arch-SKM
 #
-# Stuart Cardall 20220809
+# Stuart Cardall 20221018
 #
 ############################################
 ## USER configuration ######################
@@ -160,7 +160,7 @@ check_config() {
 
 check_pkgver() {
 	# some AUR packages use variables for $pkgver
-	# sourcing a PKGBUILD with functon names starting with an underscore gives errors
+	# sourcing a PKGBUILD with function names starting with an underscore gives errors
 	local pkgbuild=${KBUILD_DIR}/PKGBUILD search_str='prepare()'
 	local line= tmp=
 
@@ -173,7 +173,8 @@ check_pkgver() {
 		# shellcheck disable=SC1090 # $tmp location is random
 		. "$tmp" && rm -f "$tmp"
 	else
-		error "No PKGBUILD to check version"; die
+		warning "No PKGBUILD to check version"
+		return 1
 	fi
 }
 
@@ -450,7 +451,7 @@ update_kernel() {
 		esac
 	fi
 
-	# experimental automated update
+	# automated update
 	patch_pkgbuild
 }
 


### PR DESCRIPTION
* fixes first time cloning of new kernels inadvertently broken previously
* add `linux-xanmod` patch for automated building 