### PR TITLE
replace asp with devtools (pkgctl)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+Version [0.6.0]                                                       - 20230611
+ - replace asp with devtools (pkgctl)
+
 Version [0.5.8]                                                       - 20230605
  - update linux-zen patch
 

--- a/scripts/abk
+++ b/scripts/abk
@@ -6,7 +6,7 @@
 # --------------------------------------
 # https://github.com/itoffshore/Arch-SKM
 #
-# Stuart Cardall 20221018
+# Stuart Cardall 20230611
 #
 ############################################
 ## USER configuration ######################
@@ -431,11 +431,9 @@ update_kernel() {
 	# download PKGBUILD
 	if [ "$kernel_repo" = "main" ]; then
 
-		if ! asp update "$KERNEL"; then
+		if ! pkgctl repo clone --protocol=https "$KERNEL"; then
 			error "$err_msg"
 			die "$KBUILD_DIR"
-		else
-			msg "$(asp export "$KERNEL")"
 		fi
 
 	elif [ "$kernel_repo" = "aur" ]; then
@@ -682,7 +680,13 @@ patch_pkgbuild() {
 		if patch -s -p0 --dry-run < "$patch_file"; then
 
 			msg "$(patch -p0 < "$patch_file")"
-			msg2 "Ready to run: $0 -b $KERNEL"
+			msg2 "Ready to run: $0 -b $KERNEL <ENTER>"; read -r ans
+
+	                case "$ans" in
+        	          Y*|y*|"") msg "Starting build: $KERNEL"
+				    check_kernel build; time build_kernel ;;
+                	         *) msg2 "Exiting." ; die ;;
+	                esac
 		else
 			error "Cannot cleanly patch $pkgbuild"
 			ask "Remove $patch_file ? [Y/n] : "


### PR DESCRIPTION
* `asp` is now deprecated & replaced by `pkgctl` from `devtools` to clone Arch Linux repos
* adds the option to [ENTER] after `abk -u $KERNEL` to automatically build the kernel

---

  `devtools` has a lot of dependencies unnecessary if you just need `pkgctl` to clone an Arch Linux repo. Moving the following dependencies to `optdepends` gives a much smaller install of `devtools` & a working `pkgctl`:

  - `shellcheck`
  - `mercurial`
  - `subversion`