### PR TITLE
Update PKGBUILD

### DIFF
--- a/arch-sign-modules/.SRCINFO
+++ b/arch-sign-modules/.SRCINFO
@@ -1,15 +1,17 @@
 pkgbase = arch-sign-modules
 	pkgdesc = Signed (In Tree & Out of Tree) Kernel Modules for linux linux-lts linux-hardened linux-zen + AUR kernels
 	pkgver = 0.7.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/itoffshore/Arch-SKM
 	install = arch-sign-modules.install
-	arch = x86_64
-	license = GPL
+	arch = any
+	license = MIT
 	depends = git
 	depends = rsync
 	depends = python-zstandard
 	optdepends = pacman-contrib
+	optdepends = nano: default editor
+	optdepends = mousepad: default gui editor
 	source = arch-sign-modules-0.7.0.tar.gz::https://github.com/itoffshore/Arch-SKM/archive/0.7.0.tar.gz
 	md5sums = 982321bc372a2fb40e82ad9ad5924d30
 

--- a/arch-sign-modules/PKGBUILD
+++ b/arch-sign-modules/PKGBUILD
@@ -2,24 +2,21 @@
 pkgname=arch-sign-modules
 _pkgname=Arch-SKM
 pkgver=0.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Signed (In Tree & Out of Tree) Kernel Modules for linux linux-lts linux-hardened linux-zen + AUR kernels"
-arch=(x86_64)
+arch=(any)
 url="https://github.com/itoffshore/Arch-SKM"
-license=(GPL)
+license=(MIT)
 depends=('git' 'rsync' 'python-zstandard')
-optdepends=('pacman-contrib')
-makedepends=()
+optdepends=('pacman-contrib'
+            'nano: default editor'
+            'mousepad: default gui editor')
 install="$pkgname.install"
 source=($pkgname-$pkgver.tar.gz::https://github.com/itoffshore/$_pkgname/archive/$pkgver.tar.gz)
 md5sums=('982321bc372a2fb40e82ad9ad5924d30')
 
-build() {
-  return 0
-}
-
 package() {
-  cd "$srcdir/$_pkgname-$pkgver"
+  cd $_pkgname-$pkgver
   mkdir -p $pkgdir/usr/{src,bin,share/$pkgname}
 
   cp -rf certs-local $pkgdir/usr/src/
@@ -27,4 +24,6 @@ package() {
   cp Arch-Linux-PKGBUILD-example $pkgdir/usr/share/$pkgname/PKGBUILD.example
   cp -rf patches $pkgdir/usr/share/$pkgname/patches
   cp README.scripts.md $pkgdir/usr/share/$pkgname/README.scripts.md
+  # license
+  install -Dm644 LICENSE $pkgdir/usr/share/licenses/${pkgname}/LICENSE
 }


### PR DESCRIPTION
Description of changes:
1. Update arch to any, these scripts should work on any architecture.
2. License in repo is MIT, not GPL. License is installed with package now.
3. Add default editors to optdepends.
4. Remove useless build().
5. Remove unneeded $srcdir in package step.