### PR TITLE
Fix `find` shenanigans

### DIFF
--- a/scripts/abk
+++ b/scripts/abk
@@ -358,9 +358,9 @@ install_kernel() {
 	pkgdir=$(parse_makepkg PKGDEST)
 
 	kern_list=$(find "$pkgdir" -maxdepth 1 -type f -regextype posix-extended \
-			-regex ".*$KERNEL\-[0-9\.]+.*")
+			-regex ".*$KERNEL\-[0-9\.]+.*" | sort -V)
 	header_list=$(find "$pkgdir" -maxdepth 1 -type f -regextype posix-extended \
-			-regex ".*$KERNEL-headers\-[0-9\.]+.*")
+			-regex ".*$KERNEL-headers\-[0-9\.]+.*" | sort -V)
 
 	# install any manually built pkg works
 	case "$KERNEL" in


### PR DESCRIPTION
`find` doesn't sort its output - this leads on occasion to conflicts between the numbering of $kern_list and $header_list, which leads in turn to mismatched kernel and header packages being installed. Sorting both of these lists ought to fix this problem.