### PR TITLE
Add urlwatch / archive option -a / improve rebuild option -r

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Version [0.7.4]                                                       - 20240823
+ - add urlwatch examples
+ - improve kernel rebuild list / add archive option -a
+
 Version [0.7.3]                                                       - 20240426
  - fix post_install() detection of lkrg kernel module
  - update linux-hardened.patch for kernel 6.8

--- a/scripts/abk
+++ b/scripts/abk
@@ -54,6 +54,7 @@ Usage: $script [OPTIONS]
 	[ -b ] : build [ kernel-name ]
 	[ -i ] : install [ kernel-name / AUR pkgname ]
 	[ -r ] : rebuild [ kernel-name ]
+	[ -a ] : archive [ kernel-name ]
 	[ -y ] : yes ( assume YES answers during build stage )
 	[ -c ] : clean [ /path/to/directory ] ( quickly with rsync )
 	[ -s ] : clean makepkg source dir selectively ( $(parse_makepkg SRCDEST) )
@@ -81,6 +82,10 @@ Automated mode can also be enabled by adding AUTOMATED=Y to your ~/.config/abk.c
 To rebuild a previous kernel PKGBUILD that abk archived in \$BUILD_DIR/kernel-ver.tar.xz:
 ----------------------------------------------------------------------------------------
  $script -r linux-hardened
+
+To archive & version (but not build) your current \$BUILD_DIR/kernel-name:
+-------------------------------------------------------------------------
+ $script -a linux-hardened
 
 Utilities:
 --------------------------
@@ -420,7 +425,7 @@ update_kernel() {
 
 	# backup old config
 	if [ "$archive" != "nobackup" ]; then
-		archive_config "$KERNEL"
+		archive_config
 	fi
 
 	# clean old config
@@ -501,8 +506,9 @@ rebuild_kernel() {
 
 	tmp=$(mktemp)
 
+	# find output in date order
 	kern_list=$(find "$BUILD_DIR" -maxdepth 1 -type f -regextype posix-extended \
-			-regex ".*$KERNEL\-[0-9\.]+.*.tar.xz" | sort)
+			-regex ".*$KERNEL\-[0-9\.]+.*.tar.xz" -printf "%T+ %p\n" | sort | awk '{print $2}')
 
 	# print kernel archive menu
 	if [ -n "$kern_list" ]; then
@@ -535,7 +541,6 @@ rebuild_kernel() {
 	echo
 
 	# unpack archived PKGBUILD & run a build
-	archive_config
 	tar -xJf "$kernel_rebuild"
 	time build_kernel
 }
@@ -684,6 +689,10 @@ patch_pkgbuild() {
 		if patch -s -p0 --dry-run < "$patch_file"; then
 
 			msg "$(patch -p0 < "$patch_file")"
+
+			# backup new patched config
+			archive_config
+
 			msg2 "Ready to run: $0 -b $KERNEL <ENTER>"; read -r ans
 
 	                case "$ans" in
@@ -800,7 +809,7 @@ get_options() {
 	# check build dir & editors
 	check_config
 
-	while getopts ":u:b:i:r:c:w:hsloy" opt
+	while getopts ":u:b:i:r:a:c:w:hsloy" opt
 
 	do
 		if [ -n "${OPTARG}" ]; then
@@ -814,6 +823,7 @@ get_options() {
 			b) KERNEL=${OPTARG}; check_kernel build; time build_kernel ;;
 			i) KERNEL=${OPTARG}; check_kernel install; install_kernel ;;
 			r) KERNEL=${OPTARG}; check_kernel rebuild; rebuild_kernel ;;
+			a) KERNEL=${OPTARG}; check_kernel rebuild; archive_config ;;
 			y) AUTOMATED='Y' ;;
 			c) check_args "$opt" dir "$arg" ; clean_dir "$arg" sources ;;
 			s) clean_sources ;;

--- a/urlwatch/README.md
+++ b/urlwatch/README.md
@@ -1,0 +1,4 @@
+# urlwatch kernel alerts #
+
+* example files to go in ~/.config/urlwatch for urlwatch to give alerts on kernel changes with a cron example
+* [https://urlwatch.readthedocs.io](https://urlwatch.readthedocs.io)

--- a/urlwatch/urls.yaml
+++ b/urlwatch/urls.yaml
@@ -1,0 +1,26 @@
+# ~/.config/urlwatch/urlwatch.yaml #
+####################################
+---
+name: "linux-lts"
+url: "https://archlinux.org/packages/core/x86_64/linux-lts/"
+filter:
+  - element-by-tag: title
+---
+
+name: "linux-hardened"
+url: "https://www.archlinux.org/packages/extra/x86_64/linux-hardened/"
+filter:
+  - element-by-tag: title
+---
+
+name: "linux-zen"
+url: "https://www.archlinux.org/packages/extra/x86_64/linux-zen/"
+filter:
+  - element-by-tag: title
+---
+
+name: "linux"
+url: "https://archlinux.org/packages/core/x86_64/linux/"
+filter:
+  - element-by-tag: title
+---

--- a/urlwatch/urlwatch.yaml
+++ b/urlwatch/urlwatch.yaml
@@ -1,0 +1,23 @@
+# ~/.config/urlwatch/urlwatch.yaml #
+####################################
+
+display:
+  empty-diff: true
+  error: false
+  new: true
+  unchanged: false
+job_defaults:
+  all: {}
+  browser: {}
+  shell: {}
+  url:
+    ignore_connection_errors: true
+report:
+
+  ...
+
+# various alert options email / xmpp / others
+# https://urlwatch.readthedocs.io/en/latest/reporters.html
+#
+# crontab -e (check kernels every 2 hours)
+# 0 0-23/2 * * *  /usr/bin/urlwatch


### PR DESCRIPTION
## add urlwatch examples ##

* adds example config & `cron` to watch for kernel changes with [urlwatch](https://urlwatch.readthedocs.io)  for main Arch Linux kernels

## improve kernel rebuild list / add archive option -a ##

* improves kernel list in rebuild option `-r` :

  - config backups are now displayed by date rather than by number so `6.10` kernels are displayed after `6.1` / `6.2` .. `6.9`

* adds archive option `-a` to backup an existing kernel config

* automatically archives a kernel config after a `PKGBUILD` is successfully  patched:

  - `zfs` periodically trails mainline kernels, so now running a successful update with `-u` automatically creates an archive that can subsequently be rebuilt anytime with `-r` (once zfs catches up)

    This avoids the need to build a kernel not yet supported by `zfs` that may subsequently need to be rebuilt again if `gcc` has had a major version change (this happens only on `linux-hardened` & never on `linux-lts`)

    The moral of this `zfs` story: run your favourite kernel + `linux-lts` so you always have a bootable system `;o)`

