### PR TITLE
simplify kernel rebuild lists

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+Version [0.7.5]                                                       - 20240823
+ - small change to rebuild lists
+
 Version [0.7.4]                                                       - 20240823
  - add urlwatch examples
  - improve kernel rebuild list / add archive option -a

--- a/scripts/abk
+++ b/scripts/abk
@@ -506,9 +506,8 @@ rebuild_kernel() {
 
 	tmp=$(mktemp)
 
-	# find output in date order
 	kern_list=$(find "$BUILD_DIR" -maxdepth 1 -type f -regextype posix-extended \
-			-regex ".*$KERNEL\-[0-9\.]+.*.tar.xz" -printf "%T+ %p\n" | sort | awk '{print $2}')
+			-regex ".*$KERNEL\-[0-9\.]+.*.tar.xz" | sort -V)
 
 	# print kernel archive menu
 	if [ -n "$kern_list" ]; then


### PR DESCRIPTION
* replaces the recent change with `sort -V` (as already used elsewhere)